### PR TITLE
Fixes issue #5

### DIFF
--- a/lib/bootstrap-rails.rb
+++ b/lib/bootstrap-rails.rb
@@ -2,6 +2,7 @@ require "bootstrap-rails/version"
 
 module Bootstrap
   module Rails
+    require "bootstrap-rails/ie_hex_str"
     if ::Rails.version < "3.1"
       require "bootstrap-rails/railtie"
     else

--- a/lib/bootstrap-rails/ie_hex_str.rb
+++ b/lib/bootstrap-rails/ie_hex_str.rb
@@ -1,0 +1,21 @@
+require "sass"
+
+module Sass::Script::Functions
+  # returns an IE hex string for a color with an alpha channel
+  # suitable for passing to IE filters.
+  # see http://msdn.microsoft.com/en-us/library/ms532930%28v=vs.85%29.aspx
+  def ie_hex_str(color)
+    assert_type color, :Color
+    alpha = (color.alpha * 255).round
+    alpha = alpha.to_s(16).rjust(2, '0')
+    color_string = color.to_s
+    color_values = color_string.tr('#','').split('')
+    
+    r, g, b = *color_values
+    if color_values.size == 3
+      color_string = "#{r}#{r}#{g}#{g}#{b}#{b}"
+    end
+    Sass::Script::String.new("##{alpha}#{color_string}")
+  end
+  declare :ie_hex_str, :args => [:color]
+end

--- a/vendor/assets/stylesheets/mixins.scss
+++ b/vendor/assets/stylesheets/mixins.scss
@@ -172,7 +172,9 @@
   background-image: -webkit-linear-gradient(left, $startColor, $endColor); // Safari 5.1+, Chrome 10+
   background-image: -o-linear-gradient(left, $startColor, $endColor); // Opera 11.10
   background-image: linear-gradient(left, $startColor, $endColor); // Le standard
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$startColor}', endColorstr='#{$endColor}', GradientType=1); // IE9 and down
+  $ieStartColor: ie_hex_str($startColor);
+  $ieEndColor: ie_hex_str($endColor);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$ieStartColor}', endColorstr='#{$ieEndColor}', GradientType=1); // IE9 and down
 }
 @mixin gradient-vertical ($startColor: #555, $endColor: #333) {
   background-color: $endColor;
@@ -184,7 +186,9 @@
   background-image: -webkit-linear-gradient(top, $startColor, $endColor); // Safari 5.1+, Chrome 10+
   background-image: -o-linear-gradient(top, $startColor, $endColor); // Opera 11.10
   background-image: linear-gradient(top, $startColor, $endColor); // The standard
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$startColor}', endColorstr='#{$endColor}', GradientType=0); // IE9 and down
+  $ieStartColor: ie_hex_str($startColor);
+  $ieEndColor: ie_hex_str($endColor);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$ieStartColor}', endColorstr='#{$ieEndColor}', GradientType=0); // IE9 and down
 }
 @mixin gradient-directional ($startColor: #555, $endColor: #333, $deg: 45deg) {
     background-color: $endColor;
@@ -204,7 +208,9 @@
     background-image: -ms-linear-gradient($startColor, $midColor $colorStop, $endColor);
     background-image: -o-linear-gradient($startColor, $midColor $colorStop, $endColor);
     background-image: linear-gradient($startColor, $midColor $colorStop, $endColor);
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$startColor}', endColorstr='#{$endColor}', GradientType=0); // IE9 and down, gets no color-stop at all for proper fallback
+    $ieStartColor: ie_hex_str($startColor);
+    $ieEndColor: ie_hex_str($endColor);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$ieStartColor}', endColorstr='#{$ieEndColor}', GradientType=0); // IE9 and down, gets no color-stop at all for proper fallback
 }
 
 // Gradient Bar Colors for buttons and allerts


### PR DESCRIPTION
IE doesn't process gradient colors like '#333' in the DXImageTransform.Microsoft.gradient function (it considers it as '#000333' instead of '#333333')

add a Sass method to pad color arguments and pass strings to the DXImageTransform.Microsoft.gradient function. This allows for the principle of least surprise: if a user calls a mixin with a 3-digit color argument, transparently convert it to a 6-digit argument behind the scenes
