### PR TITLE
bug fix for IE gradients

### DIFF
--- a/lib/bootstrap-rails/ie_hex_str.rb
+++ b/lib/bootstrap-rails/ie_hex_str.rb
@@ -8,8 +8,8 @@ module Sass::Script::Functions
     assert_type color, :Color
     alpha = (color.alpha * 255).round
     alpha = alpha.to_s(16).rjust(2, '0')
-    color_string = color.to_s
-    color_values = color_string.tr('#','').split('')
+    color_string = color.to_s.tr('#','')
+    color_values = color_string.split('')
     
     r, g, b = *color_values
     if color_values.size == 3


### PR DESCRIPTION
before bug fix, 6-digit colors were returned with '#' between alpha and color values (e.g. '#ff#049cdb' instead of '#ff049cdb')
