### PR TITLE
Fix ie_hex_str for HTML4 colors

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,3 +39,11 @@ task "update-twitter" do
     end
   end
 end
+
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList['test/*_test.rb']
+  t.verbose = true
+end

--- a/bootstrap-rails.gemspec
+++ b/bootstrap-rails.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "railties", "~> 3.0"
   gem.add_dependency "thor",     "~> 0.14"
+  gem.add_dependency "sass"
   gem.add_development_dependency "bundler", ">= 1.0.0"
   gem.add_development_dependency "rails",   "~> 3.0"
 end

--- a/lib/bootstrap-rails.rb
+++ b/lib/bootstrap-rails.rb
@@ -1,3 +1,4 @@
+require "rails"
 require "bootstrap-rails/version"
 
 module Bootstrap

--- a/lib/bootstrap-rails/ie_hex_str.rb
+++ b/lib/bootstrap-rails/ie_hex_str.rb
@@ -8,13 +8,8 @@ module Sass::Script::Functions
     assert_type color, :Color
     alpha = (color.alpha * 255).round
     alpha = alpha.to_s(16).rjust(2, '0')
-    color_string = color.to_s.tr('#','')
-    color_values = color_string.split('')
-    
-    r, g, b = *color_values
-    if color_values.size == 3
-      color_string = "#{r}#{r}#{g}#{g}#{b}#{b}"
-    end
+    color_string = color.rgb.map {|num| num.to_s(16).rjust(2, '0')} .join
+
     Sass::Script::String.new("##{alpha}#{color_string}")
   end
   declare :ie_hex_str, :args => [:color]

--- a/test/ie_hex_str_test.rb
+++ b/test/ie_hex_str_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+require 'sass/script'
+
+class IeHexStrText < Test::Unit::TestCase
+  def test_named_color
+    assert_equal("#ffffffff", evaluate("ie_hex_str(#ffffff)"))
+  end
+
+  def test_rgba_color
+    assert_equal("#1affffff", evaluate("ie_hex_str(rgba(255, 255, 255, 0.1))"))
+  end
+
+  def test_rgb_color
+    assert_equal("#ffffffff", evaluate("ie_hex_str(rgb(255, 255, 255))"))
+  end
+
+  def test_hsl_color
+    assert_equal("#ffffffff", evaluate("ie_hex_str(hsl(100%, 100%, 100%))"))
+  end
+
+  private
+
+  def evaluate(value)
+    Sass::Script::Parser.parse(value, 0, 0).perform(Sass::Environment.new).to_s
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,2 @@
+require "bootstrap-rails"
+require 'test/unit'


### PR DESCRIPTION
`Sass::Script::Color#to_s` returns the human readable form when it belongs to the set of HTML4 colors.

This means that the following:

```
ie_hex_str(#ffffff)
```

will return:

```
#ffwhite
```

This breaks the `btn` and `breadcrumb` classes on IE (among others).
