### PR TITLE
Wrong typo for e("\9")

### DIFF
--- a/vendor/assets/stylesheets/buttons.scss
+++ b/vendor/assets/stylesheets/buttons.scss
@@ -53,7 +53,7 @@
   $shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
   @include box-shadow($shadow);
   background-color: darken($white, 10%);
-  background-color: darken($white, 15%) e("\9");
+  background-color: darken($white, 15%) \9;
   outline: 0;
 }
 

--- a/vendor/twitter/scss/buttons.scss
+++ b/vendor/twitter/scss/buttons.scss
@@ -53,7 +53,7 @@
   $shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
   @include box-shadow($shadow);
   background-color: darken($white, 10%);
-  background-color: darken($white, 15%) e("\9");
+  background-color: darken($white, 15%) \9;
   outline: 0;
 }
 


### PR DESCRIPTION
Is it come from LESS ? I don't know.
In one of my rails project, it will throw an error in my colleague's mac.
I just change it to `\9`, like other SCSS file does.
And everything looks fine.
