### PR TITLE
Fix use of 'fadein' function which doesn't exist in SCSS

### DIFF
--- a/vendor/frameworks/twitter/bootstrap/mixins.scss
+++ b/vendor/frameworks/twitter/bootstrap/mixins.scss
@@ -501,7 +501,7 @@
   text-shadow: $textShadow;
   @include gradient-vertical($primaryColor, $secondaryColor);
   border-color: $secondaryColor $secondaryColor darken($secondaryColor, 15%);
-  border-color: rgba(0,0,0,.1) rgba(0,0,0,.1) fadein(rgba(0,0,0,.1), 15%);
+  border-color: rgba(0,0,0,.1) rgba(0,0,0,.1) opacify(rgba(0,0,0,.1), 0.15);
 }
 
 


### PR DESCRIPTION
The original `fadein(rgba(0,0,0,.1), 15%)` cannot be compiled under SCSS/SASS. It will result in the same `fadein(rgba(0,0,0,.1), 15%)` in compiled CSS stylesheets.

SCSS/SASS, however, provide a similar function `opacify` (or aliased as `fade-in`), which take the amount parameter from 0 to 1. This fix should make the compiled results correct again.

Ref: http://sass-lang.com/docs/yardoc/Sass/Script/Functions.html#fade_in-instance_method
