### PR TITLE
Remove typeahead from JS manifest in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Add necessary javascript(s) files to app/assets/javascripts/application.js
 //= require twitter/bootstrap/button
 //= require twitter/bootstrap/collapse
 //= require twitter/bootstrap/carousel
-//= require twitter/bootstrap/typeahead
 //= require twitter/bootstrap/affix
 ```
 


### PR DESCRIPTION
Bootstrap v3 removed `typeahead` from Bootstrap.
