### PR TITLE
Fixes uninitialized constant error under Rails 3.2

### DIFF
--- a/lib/bootstrap-rails/engine.rb
+++ b/lib/bootstrap-rails/engine.rb
@@ -3,7 +3,7 @@ module Bootstrap
     class Engine < ::Rails::Engine
       initializer 'anjlab-bootstrap-rails-setup', :group => :all do |app|
         # Tune Sass options
-        Sass::Script::Number.precision = 15
+        ::Sass::Script::Number.precision = 15
       end
     end
   end


### PR DESCRIPTION
```
NameError: uninitialized constant Bootstrap::Sass::Script
```

I was getting the error above when using `anjlab-bootstrap-rails` in a Rails 3.2.13 app and JRuby 1.7.1. I didn't had any problem though under Rails 4 and JRuby 1.7.4, but this small change should fix the module resolution problem.
