### PR TITLE
Fixing grid to use max-width, not width.

### DIFF
--- a/app/assets/stylesheets/twitter/bootstrap/_grid.scss
+++ b/app/assets/stylesheets/twitter/bootstrap/_grid.scss
@@ -116,7 +116,7 @@
 
 @media (min-width: $screen-sm-min) {
   .container {
-    width: $container-sm;
+    max-width: $container-sm;
   }
 
   .col-sm-1,
@@ -194,7 +194,7 @@
 
 @media (min-width: $screen-md-min) {
   .container {
-    width: $container-md;
+    max-width: $container-md;
   }
   .col-md-1,
   .col-md-2,
@@ -274,7 +274,7 @@
 
 @media (min-width: $screen-lg-min) {
   .container {
-    width: $container-lg;
+    max-width: $container-lg;
   }
 
   .col-lg-1,


### PR DESCRIPTION
The Bootstrap CSS actually has these set as a `max-width`, not a `width`. This bug was messing up some layouts of mine, so I went ahead and fixed it.
