### PR TITLE
Generate md5 fingerprint for font files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -56,7 +56,7 @@ namespace :twitter do
 
     icons_path = 'app/assets/stylesheets/twitter/bootstrap/_glyphicons.scss'
     icons = File.read icons_path
-    icons.gsub!(/url\(/, "font-url(")
+    icons.gsub!(/url\((.*)\)/, 'url(asset_path(\1))')
     File.write(icons_path, icons)
   end
 

--- a/app/assets/stylesheets/twitter/bootstrap/_glyphicons.scss
+++ b/app/assets/stylesheets/twitter/bootstrap/_glyphicons.scss
@@ -10,11 +10,11 @@
 // Import the fonts
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: font-url('#{$icon-font-path}#{$icon-font-name}.eot');
-  src: font-url('#{$icon-font-path}#{$icon-font-name}.eot?#iefix') format('embedded-opentype'),
-       font-url('#{$icon-font-path}#{$icon-font-name}.woff') format('woff'),
-       font-url('#{$icon-font-path}#{$icon-font-name}.ttf') format('truetype'),
-       font-url('#{$icon-font-path}#{$icon-font-name}.svg#glyphicons-halflingsregular') format('svg');
+  src: url(asset_path('#{$icon-font-path}#{$icon-font-name}.eot'));
+  src: url(asset_path('#{$icon-font-path}#{$icon-font-name}.eot?#iefix')) format('embedded-opentype'),
+       url(asset_path('#{$icon-font-path}#{$icon-font-name}.woff')) format('woff'),
+       url(asset_path('#{$icon-font-path}#{$icon-font-name}.ttf')) format('truetype'),
+       url(asset_path('#{$icon-font-path}#{$icon-font-name}.svg#glyphicons-halflingsregular')) format('svg');
 }
 
 // Catchall baseclass


### PR DESCRIPTION
Having problems with the font files not have the MD5 fingerprints when precompiling assets.
