### PR TITLE
Use pessimistic operator in README.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can install from latest build via git
 
 ``` ruby
 
-gem 'anjlab-bootstrap-rails', '>= 3.0.0.0', :require => 'bootstrap-rails'
+gem 'anjlab-bootstrap-rails', '~> 3.0.0.3', :require => 'bootstrap-rails'
 ```
 
 and run bundle install.


### PR DESCRIPTION
I propose changing the Gemfile operator in the README from `>=` to `~>`.

Bootstrap changes significantly from version to version.  When, for example, Bootstrap 4 comes out, anyone who is using `>=` and runs `bundle update` will have issues.

For further argument in favor of the pessimistic operator please see:
http://yehudakatz.com/2010/08/21/using-considered-harmful-or-whats-wrong-with/
