### PR TITLE
Fix table-row-variant mixin

### DIFF
--- a/app/assets/stylesheets/twitter/bootstrap/_mixins.scss
+++ b/app/assets/stylesheets/twitter/bootstrap/_mixins.scss
@@ -433,22 +433,24 @@
   .table > thead > tr,
   .table > tbody > tr,
   .table > tfoot > tr {
-    > td.#{state},
-    > th.#{state},
-    &.#{state} > td,
-    &.#{state} > th {
+    > td.#{$state},
+    > th.#{$state},
+    &.#{$state} > td,
+    &.#{$state} > th {
       background-color: $background;
+      border-color: $border;
     }
   }
 
   // Hover states for `.table-hover`
   // Note: this is not available for cells or rows within `thead` or `tfoot`.
   .table-hover > tbody > tr {
-    > td.#{state}:hover,
-    > th.#{state}:hover,
-    &.#{state}:hover > td,
-    &.#{state}:hover > th {
+    > td.#{$state}:hover,
+    > th.#{$state}:hover,
+    &.#{$state}:hover > td,
+    &.#{$state}:hover > th {
       background-color: darken($background, 5%);
+      border-color: darken($border, 5%);
     }
   }
 }


### PR DESCRIPTION
Added missing '$' before variable names in the table-row-variant mixin, and added border color css.
